### PR TITLE
Use URL query param as source of truth for search

### DIFF
--- a/src/app/cards/cards-routing.module.ts
+++ b/src/app/cards/cards-routing.module.ts
@@ -1,16 +1,21 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 
+import * as fromGuards from './guards';
+
 import { CardsPageComponent } from './components/cards-page/cards-page.component';
 import { CardShowPageComponent } from './components/card-show-page/card-show-page.component';
 
 const routes: Routes = [
   {
     path: '',
-    component: CardsPageComponent
+    canActivate: [fromGuards.CardsGuard],
+    component: CardsPageComponent,
+    runGuardsAndResolvers: 'paramsOrQueryParamsChange'
   },
   {
     path: ':cardId',
+    canActivate: [fromGuards.CardExistsGuard],
     component: CardShowPageComponent
   }
 ];

--- a/src/app/cards/components/card-list/card-list.component.ts
+++ b/src/app/cards/components/card-list/card-list.component.ts
@@ -1,15 +1,17 @@
-import { Component, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import { Observable } from 'rxjs';
 
 import { CardsStoreService } from '@/app/cards/services/cards-store.service';
+import { Card } from '@/app/models/card';
 
 @Component({
   selector: 'tmm-card-list',
   templateUrl: './card-list.component.html',
-  styleUrls: ['./card-list.component.scss']
+  styleUrls: ['./card-list.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class CardListComponent implements OnInit {
-  public cards$: Observable<any[]>;
+  public cards$: Observable<Card[]>;
 
   constructor(
     private cardsStore: CardsStoreService

--- a/src/app/cards/components/card-show-page/card-show-page.component.html
+++ b/src/app/cards/components/card-show-page/card-show-page.component.html
@@ -1,4 +1,4 @@
-<mat-card class="card-card">
+<mat-card class="card-card" *ngIf="card$ | async as card">
   <mat-card-header>
     <mat-card-title>{{card.name}}</mat-card-title>
     <mat-card-subtitle>{{card.set}}</mat-card-subtitle>

--- a/src/app/cards/components/card-show-page/card-show-page.component.ts
+++ b/src/app/cards/components/card-show-page/card-show-page.component.ts
@@ -1,27 +1,24 @@
-import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
-import { CardsService } from '../../../core/services/cards.service';
+import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { CardsStoreService } from '@/app/cards/services/cards-store.service';
+import { Card } from '@/app/models/card';
 
 @Component({
   selector: 'tmm-card-show-page',
   templateUrl: './card-show-page.component.html',
-  styleUrls: ['./card-show-page.component.scss']
+  styleUrls: ['./card-show-page.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class CardShowPageComponent implements OnInit {
-  public card: any = {};
+  public card$: Observable<Card>;
 
   constructor(
-    private activatedRoute: ActivatedRoute,
-    private cardsService: CardsService
+    private cardsStore: CardsStoreService
   ) { }
 
   public ngOnInit(): void {
-    this.activatedRoute.paramMap.subscribe((paramMap) => {
-      const cardId = paramMap.get('cardId');
-      this.cardsService.show(cardId).subscribe((card) => {
-        this.card = card;
-      });
-    });
+    this.card$ = this.cardsStore.selectedCard$;
   }
 
 }

--- a/src/app/cards/components/cards-page/cards-page.component.ts
+++ b/src/app/cards/components/cards-page/cards-page.component.ts
@@ -1,9 +1,10 @@
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 
 @Component({
   selector: 'tmm-cards-page',
   templateUrl: './cards-page.component.html',
-  styleUrls: ['./cards-page.component.scss']
+  styleUrls: ['./cards-page.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class CardsPageComponent {
 }

--- a/src/app/cards/guards/card-exists.guard.ts
+++ b/src/app/cards/guards/card-exists.guard.ts
@@ -1,0 +1,42 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, CanActivate } from '@angular/router';
+import { Observable, of, zip } from 'rxjs';
+import { catchError, filter, map, switchMap, take, tap } from 'rxjs/operators';
+
+import { Store } from '@ngrx/store';
+
+import * as fromStore from '../store';
+
+@Injectable()
+export class CardExistsGuard implements CanActivate {
+  constructor(private store: Store<fromStore.CardsState>) {}
+
+  canActivate(route: ActivatedRouteSnapshot): Observable<boolean> {
+    const cardId = route.paramMap.get('cardId');
+    this.store.dispatch(fromStore.setSelectedCardId({ cardId }));
+    return this.checkCards(cardId).pipe(
+      switchMap(() => of(true)),
+      catchError(() => of(false))
+    );
+  }
+
+  private cardExists(cardId: string): Observable<boolean> {
+    return this.store.select(fromStore.selectCardEntities).pipe(
+      map((entities) => !!entities[cardId]),
+      take(2) // Once for checking if the card exists, the second to give the card a chance to load
+    );
+  }
+
+  private checkCards(cardId: string): Observable<boolean> {
+    return zip(this.cardExists(cardId)).pipe(
+      tap(([cardLoaded]) => {
+        if (!cardLoaded) {
+          this.store.dispatch(fromStore.loadCards({ ids: [cardId] }));
+        }
+      }),
+      map(([cardLoaded]) => cardLoaded),
+      filter((cardLoaded) => cardLoaded),
+      take(1)
+    );
+  }
+}

--- a/src/app/cards/guards/cards.guard.ts
+++ b/src/app/cards/guards/cards.guard.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, CanActivate } from '@angular/router';
+import { Observable, of } from 'rxjs';
+import { catchError, switchMap, tap } from 'rxjs/operators';
+
+import { Store } from '@ngrx/store';
+
+import * as fromStore from '../store';
+
+@Injectable()
+export class CardsGuard implements CanActivate {
+  constructor(private store: Store<fromStore.CardsState>) {}
+
+  canActivate(route: ActivatedRouteSnapshot): Observable<boolean> {
+    return of({}).pipe(
+      tap(() => {
+        this.store.dispatch(fromStore.loadCards({}));
+      }),
+      switchMap(() => of(true)),
+      catchError(() => of(false))
+    );
+  }
+}

--- a/src/app/cards/guards/index.ts
+++ b/src/app/cards/guards/index.ts
@@ -1,1 +1,7 @@
-export const guards: any[] = [];
+import { CardExistsGuard } from '@/app/cards/guards/card-exists.guard';
+import { CardsGuard } from '@/app/cards/guards/cards.guard';
+
+export const guards: any[] = [CardExistsGuard, CardsGuard];
+
+export * from '@/app/cards/guards/card-exists.guard';
+export * from '@/app/cards/guards/cards.guard';

--- a/src/app/cards/services/cards-store.service.ts
+++ b/src/app/cards/services/cards-store.service.ts
@@ -6,8 +6,8 @@ import * as fromStore from '../store';
   providedIn: 'root'
 })
 export class CardsStoreService {
-  public searchTerm$ = this.store.select(fromStore.selectSearchTerm);
   public cards$ = this.store.select(fromStore.selectCards);
+  public selectedCard$ = this.store.select(fromStore.selectedCard);
   public cardsLoading$ = this.store.select(fromStore.selectCardsLoading);
   public cardsLoaded$ = this.store.select(fromStore.selectCardsLoaded);
   public cardErrors$ = this.store.select(fromStore.selectCardsError);
@@ -15,12 +15,4 @@ export class CardsStoreService {
   constructor(
     private store: Store<fromStore.CardsState>
   ) { }
-
-  public updateSearch(search: string): void {
-    this.store.dispatch(fromStore.updateSearch({ search }));
-  }
-
-  public getCards(searchTerm: string, page: string = '1', perPage?: string): void {
-    this.store.dispatch(fromStore.loadCards({ search: searchTerm, page, perPage }));
-  }
 }

--- a/src/app/cards/store/actions/card.actions.ts
+++ b/src/app/cards/store/actions/card.actions.ts
@@ -1,10 +1,10 @@
 import { createAction, props } from '@ngrx/store';
 
 export const loadCards = createAction('[Cards] Load Cards', props<{
-  search?: string,
   page?: string,
-  perPage?: string
+  perPage?: string,
+  ids?: string[]
 }>());
 export const loadCardsSuccess = createAction('[Cards] Load Cards Success', props<{ cards: any[] }>());
 export const loadCardsError = createAction('[Cards] Load Cards Error', props<{ errors: any[] }>());
-export const updateSearch = createAction('[Cards] Update Search', props<{ search: string }>());
+export const setSelectedCardId = createAction('[Cards] Set Selected Card ID', props<{ cardId: string }>());

--- a/src/app/cards/store/effects/card.effects.ts
+++ b/src/app/cards/store/effects/card.effects.ts
@@ -1,37 +1,29 @@
 import { Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { CardsService } from '@/app/core/services/cards.service';
-import { catchError, distinctUntilChanged, map, mergeMap, switchMap } from 'rxjs/operators';
+import { catchError, distinctUntilChanged, map, mergeMap, switchMap, take } from 'rxjs/operators';
 import { of } from 'rxjs';
+
+import { Store } from '@ngrx/store';
 
 import * as fromActions from '../actions';
 import * as fromRoot from '@/app/store';
-import { ROUTER_NAVIGATED } from '@ngrx/router-store';
-import { Store } from '@ngrx/store';
 
 @Injectable()
 export class CardEffects {
   loadCards$ = createEffect(() => this.actions$.pipe(
     ofType(fromActions.loadCards),
     distinctUntilChanged(),
-    mergeMap(({ search }) => this.cardsService.index(search)
-      .pipe(
-        map(({ cards }) => fromActions.loadCardsSuccess({ cards })),
-        catchError((err) => of(fromActions.loadCardsError({ errors: err })))
-      ))
-  ));
-
-  updateUrl$ = createEffect(() => this.actions$.pipe(
-    ofType(fromActions.updateSearch),
-    distinctUntilChanged(),
-    map(({ search }) => fromRoot.Go({ path: ['/cards'], query: { search } }))
-  ));
-
-  queryParamsChanged$ = createEffect(() => this.actions$.pipe(
-    ofType(ROUTER_NAVIGATED),
-    switchMap(() => this.store.select(fromRoot.getQueryParams)),
-    distinctUntilChanged(),
-    map(({ search }) => fromActions.loadCards({ search }))
+    mergeMap(({ ids }) => {
+      return this.store.select(fromRoot.getQueryParams).pipe(
+        switchMap(({ search }) => {
+          return this.cardsService.index(search, '1', ids);
+        }),
+        take(1)
+      );
+    }),
+    map(({ cards }) => fromActions.loadCardsSuccess({ cards })),
+    catchError((err) => of(fromActions.loadCardsError({ errors: err })))
   ));
 
   constructor(

--- a/src/app/cards/store/reducers/card.reducers.ts
+++ b/src/app/cards/store/reducers/card.reducers.ts
@@ -2,35 +2,51 @@ import * as cardActions from '../actions/card.actions';
 import { Action, createReducer, on } from '@ngrx/store';
 
 export interface CardsState {
-  cards: any[];
   search: string;
   loading: boolean;
   loaded: boolean;
   errors: any[];
+  entities: { [key: string]: any };
+  selectedCardId: string;
+  ids: string[];
 }
 
 export const initialState: CardsState = {
-  cards: [],
   search: '',
   loading: false,
   loaded: false,
-  errors: null
+  errors: null,
+  entities: {},
+  selectedCardId: null,
+  ids: []
 };
 
 const cardsReducer = createReducer(
   initialState,
-  on(cardActions.loadCards, (state, { search }) => {
+  on(cardActions.loadCards, (state, { ids }) => {
     return {
       ...state,
       loading: true,
       loaded: false,
-      search
+      ids
     };
   }),
-  on(cardActions.loadCardsSuccess, (state, {cards}) => {
+  on(cardActions.setSelectedCardId, (state, { cardId }) => {
     return {
       ...state,
-      cards,
+      selectedCardId: cardId
+    };
+  }),
+  on(cardActions.loadCardsSuccess, (state, { cards }) => {
+    const entities = cards.reduce((accum, card) => {
+      return {
+        ...accum,
+        [card.id]: card
+      };
+    }, {});
+    return {
+      ...state,
+      entities,
       loading: false,
       loaded: true
     };
@@ -41,13 +57,6 @@ const cardsReducer = createReducer(
       loading: false,
       loaded: false,
       errors
-    };
-  }),
-  on(cardActions.updateSearch, (state, { search }) => {
-    return {
-      ...state,
-      search,
-      loaded: false
     };
   })
 );

--- a/src/app/cards/store/selectors/card.selectors.ts
+++ b/src/app/cards/store/selectors/card.selectors.ts
@@ -8,9 +8,25 @@ export const selectCardState = createSelector(
   (state: fromFeature.CardsState) => state.cards
 );
 
-export const selectCards = createSelector(
+export const selectCardEntities = createSelector(
   selectCardState,
-  (state: fromCards.CardsState) => state.cards
+  (state: fromCards.CardsState) => state.entities
+);
+
+export const selectCards = createSelector(
+  selectCardEntities,
+  (entities) => Object.keys(entities).map((cardId) => entities[cardId])
+);
+
+export const selectedCardId = createSelector(
+  selectCardState,
+  (state) => state.selectedCardId
+);
+
+export const selectedCard = createSelector(
+  selectCardEntities,
+  selectedCardId,
+  (entities, cardId) => entities[cardId]
 );
 
 export const selectCardsLoading = createSelector(

--- a/src/app/core/services/cards.service.ts
+++ b/src/app/core/services/cards.service.ts
@@ -11,9 +11,13 @@ export class CardsService {
     private http: HttpClient
   ) { }
 
-  public index(search: string = '', page: string = '1', perPage?: string): Observable<any> {
-    const params = { q: search, page, perPage };
-    if (params.q == null) { delete params.q; }
+  public index(search: string = '', page: string = '1', ids?: string[], perPage?: string): Observable<any> {
+    const params = { q: search, page, perPage, ids };
+    for (const param in params) {
+      if (params.hasOwnProperty(param)) {
+        if (!params[param]) { delete params[param]; }
+      }
+    }
     return this.http.get('/cards', { params });
   }
 

--- a/src/app/models/card.ts
+++ b/src/app/models/card.ts
@@ -1,0 +1,13 @@
+export interface Card {
+  id: string;
+  name: string;
+  set: string;
+  image: string;
+  png: string;
+  art: string;
+  card_type: string;
+  card_text: string;
+  power: number;
+  toughness: number;
+  legalities: string[];
+}

--- a/src/app/shared/components/search-input/search-input.component.ts
+++ b/src/app/shared/components/search-input/search-input.component.ts
@@ -1,9 +1,11 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { FormControl } from '@angular/forms';
 import { Subject } from 'rxjs';
-import { debounceTime, distinctUntilChanged, takeUntil } from 'rxjs/operators';
+import { debounceTime, distinctUntilChanged, map, takeUntil } from 'rxjs/operators';
 
-import { CardsStoreService } from '@/app/cards/services/cards-store.service';
+import { Store } from '@ngrx/store';
+
+import * as fromRoot from '@/app/store';
 
 @Component({
   selector: 'tmm-search-input',
@@ -16,12 +18,14 @@ export class SearchInputComponent implements OnInit, OnDestroy {
   private destroy = new Subject<void>();
 
   constructor(
-    private cardsStore: CardsStoreService
+    private store: Store<fromRoot.State>
   ) { }
 
   public ngOnInit() {
     this.subscribeToSearch();
-    this.cardsStore.searchTerm$.pipe(
+    this.store.select(fromRoot.getQueryParams).pipe(
+      map(({ search }) => search),
+      distinctUntilChanged(),
       takeUntil(this.destroy)
     ).subscribe((search) => {
       this.searchText.setValue(search, { emitEvent: false });
@@ -39,7 +43,7 @@ export class SearchInputComponent implements OnInit, OnDestroy {
       distinctUntilChanged(),
       takeUntil(this.destroy)
     ).subscribe((text) => {
-      this.cardsStore.updateSearch(text);
+      this.store.dispatch(fromRoot.Go({ path: ['/cards'], query: { search: text } }));
     });
   }
 


### PR DESCRIPTION
Trying to keep the query params in the URL updated if search changed, and at the same time keeping search updated if the query params changed was a headache and kept resulting in infinite loops.

Instead, let the query params be the source of truth for search. This does limit the caching ability on checking if the cards are loaded or not. Perhaps I'll come up with a good cache-busting technique later but for now this gets everything to flowing correctly.